### PR TITLE
Remove redundant int cast

### DIFF
--- a/lib/EioHandle.php
+++ b/lib/EioHandle.php
@@ -214,7 +214,6 @@ class EioHandle implements Handle {
             throw new PendingOperationError;
         }
 
-        $offset = (int) $offset;
         switch ($whence) {
             case \SEEK_SET:
                 $this->position = $offset;


### PR DESCRIPTION
The int cast is redundant due to the int parameter type hint. Presumably it's left over from PHP5 days.