### PR TITLE
Add optional time parameters to touch function

### DIFF
--- a/lib/BlockingDriver.php
+++ b/lib/BlockingDriver.php
@@ -324,8 +324,10 @@ class BlockingDriver implements Driver {
     /**
      * {@inheritdoc}
      */
-    public function touch(string $path): Promise {
-        return new Success((bool) \touch($path));
+    public function touch(string $path, int $time = null, int $atime = null): Promise {
+        $time = $time ?? \time();
+        $atime = $atime ?? $time;
+        return new Success((bool) \touch($path, $time, $atime));
     }
 
     /**

--- a/lib/Driver.php
+++ b/lib/Driver.php
@@ -196,9 +196,11 @@ interface Driver {
      * If the file does not exist it will be created automatically.
      *
      * @param string $path
+     * @param int $time The touch time. If $time is not supplied, the current system time is used.
+     * @param int $atime The access time. If $atime is not supplied, value passed to the $time parameter is used.
      * @return \Amp\Promise
      */
-    public function touch(string $path): Promise;
+    public function touch(string $path, int $time = null, int $atime = null): Promise;
 
     /**
      * Buffer the specified file's contents.

--- a/lib/EioDriver.php
+++ b/lib/EioDriver.php
@@ -464,14 +464,15 @@ class EioDriver implements Driver {
     /**
      * {@inheritdoc}
      */
-    public function touch(string $path): Promise {
-        $atime = $mtime = \time();
+    public function touch(string $path, int $time = null, int $atime = null): Promise {
+        $time = $time ?? \time();
+        $atime = $atime ?? $time;
 
         $deferred = new Deferred;
         $this->poll->listen($deferred->promise());
 
         $priority = \EIO_PRI_DEFAULT;
-        \eio_utime($path, $atime, $mtime, $priority, [$this, "onGenericResult"], $deferred);
+        \eio_utime($path, $atime, $time, $priority, [$this, "onGenericResult"], $deferred);
 
         return $deferred->promise();
     }

--- a/lib/Internal/FileTask.php
+++ b/lib/Internal/FileTask.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Amp\File\Internal;
 
 use Amp\File\BlockingDriver;

--- a/lib/ParallelDriver.php
+++ b/lib/ParallelDriver.php
@@ -264,8 +264,8 @@ class ParallelDriver implements Driver {
     /**
      * {@inheritdoc}
      */
-    public function touch(string $path): Promise {
-        return new Coroutine($this->runFileTask(new Internal\FileTask("touch", [$path])));
+    public function touch(string $path, int $time = null, int $atime = null): Promise {
+        return new Coroutine($this->runFileTask(new Internal\FileTask("touch", [$path, $time, $atime])));
     }
 
     /**

--- a/lib/UvDriver.php
+++ b/lib/UvDriver.php
@@ -458,13 +458,14 @@ class UvDriver implements Driver {
     /**
      * {@inheritdoc}
      */
-    public function touch(string $path): Promise {
-        $atime = $mtime = time();
+    public function touch(string $path, int $time = null, int $atime = null): Promise {
+        $time = $time ?? \time();
+        $atime = $atime ?? $time;
 
         $deferred = new Deferred;
         $this->poll->listen($deferred->promise());
 
-        \uv_fs_utime($this->loop, $path, $mtime, $atime, function () use ($deferred) {
+        \uv_fs_utime($this->loop, $path, $time, $atime, function () use ($deferred) {
             // The uv_fs_utime() callback does not receive any args at this time
             $deferred->resolve(true);
         });

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -305,10 +305,12 @@ function chown(string $path, int $uid, int $gid = -1): Promise {
  * If the file does not exist it will be created automatically.
  *
  * @param string $path
+ * @param int $time The touch time. If $time is not supplied, the current system time is used.
+ * @param int $atime The access time. If $atime is not supplied, value passed to the $time parameter is used.
  * @return \Amp\Promise<null>
  */
-function touch(string $path): Promise {
-    return filesystem()->touch($path);
+function touch(string $path, int $time = null, int $atime = null): Promise {
+    return filesystem()->touch($path, $time, $atime);
 }
 
 /**

--- a/test/DriverTest.php
+++ b/test/DriverTest.php
@@ -316,8 +316,7 @@ abstract class DriverTest extends TestCase {
             yield File\put($touch, "touch me");
 
             $oldStat = (yield File\stat($touch));
-            sleep(1);
-            yield File\touch($touch);
+            yield File\touch($touch, \time() + 10, \time() + 20);
             File\StatCache::clear($touch);
             $newStat = (yield File\stat($touch));
             yield File\unlink($touch);


### PR DESCRIPTION
Implementation for #21:
2 optional parameters added:
* `time`
The touch time. If time is not supplied, the current system time `\time()` is used
* `atime`
If present, the access time of the given filename is set to the value of `atime`. Otherwise, it is set to the value passed to the `time` parameter. If neither are present, the current system time `\time()` is used.