### PR TITLE
Fixes invalid stat result in UvDriver

### DIFF
--- a/lib/UvDriver.php
+++ b/lib/UvDriver.php
@@ -123,6 +123,14 @@ class UvDriver implements Driver {
             if (empty($fh)) {
                 $stat = null;
             } else {
+                // link is not a valid stat type but returned by the uv extension
+                // change link to nlink
+                if (isset($stat['link'])) {
+                    $stat['nlink'] = $stat['link'];
+
+                    unset($stat['link']);
+                }
+
                 StatCache::set($path, $stat);
             }
 

--- a/test/DriverTest.php
+++ b/test/DriverTest.php
@@ -74,6 +74,7 @@ abstract class DriverTest extends TestCase {
             $fixtureDir = Fixture::path();
             $stat = (yield File\stat("{$fixtureDir}/small.txt"));
             $this->assertInternalType("array", $stat);
+            $this->assertStatSame(\stat("{$fixtureDir}/small.txt"), $stat);
         });
     }
 
@@ -82,6 +83,7 @@ abstract class DriverTest extends TestCase {
             $fixtureDir = Fixture::path();
             $stat = (yield File\stat("{$fixtureDir}/dir"));
             $this->assertInternalType("array", $stat);
+            $this->assertStatSame(\stat("{$fixtureDir}/dir"), $stat);
         });
     }
 
@@ -326,6 +328,24 @@ abstract class DriverTest extends TestCase {
             $this->assertTrue($newStat["atime"] > $oldStat["atime"]);
             $this->assertTrue($newStat["mtime"] > $oldStat["mtime"]);
         });
+    }
+
+    private function assertStatSame(array $expected, array $actual) {
+        $filter = function (array $stat) {
+            $filtered = \array_filter(
+                $stat,
+                function (string $key): bool {
+                    return !\is_numeric($key);
+                },
+                ARRAY_FILTER_USE_KEY
+            );
+
+            ksort($filtered);
+
+            return $filtered;
+        };
+
+        $this->assertSame($filter($expected), $filter($actual));
     }
 
     /**


### PR DESCRIPTION
`UvDriver` is the default `File\Driver` but the underlying uv extension installed via `travis/install-uv.sh` returns an invalid stat result, i.e. it contains the key `link`, this should be `nlink` https://linux.die.net/man/2/stat. This PR adds a test and remaps link -> nlink if it is detected.