### PR TITLE
Add AsyncFileMutex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_install:
 
 install:
   - if [ "$TRAVIS_PHP_VERSION" = "nightly" ]; then
-      composer update -n --prefer-dist --ignore-platform-reqs;
+      composer update -n --ignore-platform-reqs;
     else
-      composer update -n --prefer-dist;
+      composer update -n;
     fi
   - composer show
 

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,13 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Amp\\File\\Test\\": "test"
+            "Amp\\File\\Test\\": "test",
+            "Amp\\Sync\\Test\\": "vendor/amphp/sync/test"
+        }
+    },
+    "config": {
+        "preferred-install": {
+            "amphp/sync": "source"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": ">=7.1",
         "amphp/amp": "^2.2",
         "amphp/byte-stream": "^1.6.1",
-        "amphp/parallel": "^1.2"
+        "amphp/parallel": "^1.2",
+        "amphp/sync": "^1.3"
     },
     "require-dev": {
         "ext-eio": "^2",

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -61,12 +61,16 @@ final class AsyncFileMutex implements Mutex
      *
      * @throws SyncException If the unlock operation failed.
      */
-    protected function release(): void
+    private function release(): void
     {
         unlink($this->fileName)->onResolve(
             function (?\Throwable $exception) {
                 if ($exception !== null) {
-                    throw new SyncException('Failed to unlock the mutex file.', 0, $exception);
+                    throw new SyncException(
+                        'Failed to unlock the mutex file: ' . $this->file,
+                        0,
+                        $exception
+                    );
                 }
             }
         );

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -5,6 +5,7 @@ namespace Amp\File\Sync;
 use Amp\Coroutine;
 use Amp\Delayed;
 use Amp\Promise;
+use Amp\Sync\Lock;
 use Amp\Sync\Mutex;
 use Amp\Sync\SyncException;
 use function Amp\File\open;

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -12,7 +12,7 @@ use function Amp\File\unlink;
 
 final class AsyncFileMutex implements Mutex
 {
-    public const LATENCY_TIMEOUT = 10;
+    private const LATENCY_TIMEOUT = 10;
 
     /** @var string The full path to the lock file. */
     private $fileName;

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -20,7 +20,7 @@ final class AsyncFileMutex implements Mutex
     private $fileName;
 
     /**
-     * @param string|null $fileName Name of temporary file to use as a mutex.
+     * @param string $fileName Name of temporary file to use as a mutex.
      */
     public function __construct(string $fileName)
     {

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -64,7 +64,7 @@ final class AsyncFileMutex implements Mutex
     private function release(): void
     {
         unlink($this->fileName)->onResolve(
-            function (?\Throwable $exception) {
+            function (?\Throwable $exception): void {
                 if ($exception !== null) {
                     throw new SyncException(
                         'Failed to unlock the mutex file: ' . $this->file,

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -10,7 +10,7 @@ use Amp\Sync\SyncException;
 use function Amp\File\open;
 use function Amp\File\unlink;
 
-class AsyncFileMutex implements Mutex
+final class AsyncFileMutex implements Mutex
 {
     public const LATENCY_TIMEOUT = 10;
 

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -66,8 +66,6 @@ final class AsyncFileMutex implements Mutex
 
     /**
      * Releases the lock on the mutex.
-     *
-     * @throws SyncException If the unlock operation failed.
      */
     private function release(): void
     {

--- a/src/Sync/AsyncFileMutex.php
+++ b/src/Sync/AsyncFileMutex.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Amp\File\Sync;
+
+use Amp\Coroutine;
+use Amp\Delayed;
+use Amp\Promise;
+use Amp\Sync\Mutex;
+use Amp\Sync\SyncException;
+use function Amp\File\open;
+use function Amp\File\unlink;
+
+class AsyncFileMutex implements Mutex
+{
+    public const LATENCY_TIMEOUT = 10;
+
+    /** @var string The full path to the lock file. */
+    private $fileName;
+
+    /**
+     * @param string|null $fileName Name of temporary file to use as a mutex.
+     */
+    public function __construct(string $fileName)
+    {
+        $this->fileName = $fileName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function acquire(): Promise
+    {
+        return new Coroutine($this->doAcquire());
+    }
+
+    /**
+     * @coroutine
+     *
+     * @return \Generator
+     */
+    private function doAcquire(): \Generator
+    {
+        // Try to create the lock file. If the file already exists, someone else
+        // has the lock, so set an asynchronous timer and try again.
+        while (($file = yield open($this->fileName, 'x')) === false) {
+            yield new Delayed(self::LATENCY_TIMEOUT);
+        }
+
+        // Return a lock object that can be used to release the lock on the mutex.
+        $lock = new Lock(0, function (): void {
+            $this->release();
+        });
+
+        yield $file->close();
+
+        return $lock;
+    }
+
+    /**
+     * Releases the lock on the mutex.
+     *
+     * @throws SyncException If the unlock operation failed.
+     */
+    protected function release(): void
+    {
+        unlink($this->fileName)->onResolve(
+            function (?\Throwable $exception) {
+                if ($exception !== null) {
+                    throw new SyncException('Failed to unlock the mutex file.', 0, $exception);
+                }
+            }
+        );
+    }
+}

--- a/src/UvDriver.php
+++ b/src/UvDriver.php
@@ -57,6 +57,8 @@ final class UvDriver implements Driver
 
         $openArr = [$mode, $path, $deferred];
         \uv_fs_open($this->loop, $path, $flags, $chmod, function ($fh) use ($openArr): void {
+            var_export(array_map('gettype', func_get_args()));
+            var_export(func_get_args());
             if ($fh) {
                 $this->onOpenHandle($fh, $openArr);
             } else {

--- a/src/UvDriver.php
+++ b/src/UvDriver.php
@@ -57,9 +57,7 @@ final class UvDriver implements Driver
 
         $openArr = [$mode, $path, $deferred];
         \uv_fs_open($this->loop, $path, $flags, $chmod, function ($fh) use ($openArr): void {
-            var_export(array_map('gettype', func_get_args()));
-            var_export(func_get_args());
-            if ($fh) {
+            if (\is_resource($fh)) {
                 $this->onOpenHandle($fh, $openArr);
             } else {
                 [, $path, $deferred] = $openArr;

--- a/test/Sync/AsyncFileMutexTest.php
+++ b/test/Sync/AsyncFileMutexTest.php
@@ -2,7 +2,7 @@
 
 namespace Amp\File\Test\Sync;
 
-use Amp\Sync\FileMutex;
+use Amp\File\Sync\AsyncFileMutex;
 use Amp\Sync\Mutex;
 use Amp\Sync\Test\AbstractMutexTest;
 
@@ -10,6 +10,6 @@ final class AsyncFileMutexTest extends AbstractMutexTest
 {
     public function createMutex(): Mutex
     {
-        return new FileMutex(\tempnam(\sys_get_temp_dir(), 'mutex-') . '.lock');
+        return new AsyncFileMutex(\tempnam(\sys_get_temp_dir(), 'mutex-') . '.lock');
     }
 }

--- a/test/Sync/AsyncFileMutexTest.php
+++ b/test/Sync/AsyncFileMutexTest.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Amp\File\Test\Sync;
+
+use Amp\Sync\FileMutex;
+use Amp\Sync\Mutex;
+use Amp\Sync\Test\AbstractMutexTest;
+
+final class AsyncFileMutexTest extends AbstractMutexTest
+{
+    public function createMutex(): Mutex
+    {
+        return new FileMutex(\tempnam(\sys_get_temp_dir(), 'mutex-') . '.lock');
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/amphp/sync/issues/8

I'm not exactly sure how to write a test for this since [AbstractMutexTest](https://github.com/amphp/sync/blob/master/test/AbstractMutexTest.php) is in the tests directory and not available when installing amphp/sync as a dependency. I can either copy it or move it to src directory to have it available (other packages like Symfony do that to make abstract tests available for dependencies). Which way should I go?