### PR TITLE
Fix EioDriver

### DIFF
--- a/src/Internal/EioPoll.php
+++ b/src/Internal/EioPoll.php
@@ -25,6 +25,9 @@ final class EioPoll
         $this->driver = $driver;
 
         if (!self::$stream) {
+            if (\function_exists('eio_init')) {
+                \eio_init();
+            }
             self::$stream = \eio_get_event_stream();
         }
 


### PR DESCRIPTION
Closes #59

You removed the call to `eio_init()` [here](https://github.com/amphp/file/commit/f406950680131f68a4e2a5a53ddbff92748ec8c1), however this completely breaks the EioDriver. When I try to use it, the script will hang until I press enter and then continues. Calling `eio_init()` fixes the problem.

What's more you claim that it was deprecated in eio v2 and removed in eio v3. However I can confirm that it still exists in eio `3.0.0RC2` and even this version breaks when it isn't called.

In my opinion we should still call it but perhaps wrap it with function exists. Hopefully if eio does remove it in the future the bug should be fixed.