### PR TITLE
#70 - fix createDirectoryRecursively with end slash in async drivers

### DIFF
--- a/src/Driver/EioDriver.php
+++ b/src/Driver/EioDriver.php
@@ -146,6 +146,7 @@ final class EioDriver implements Driver
         $priority = \EIO_PRI_DEFAULT;
 
         $path = \str_replace("/", DIRECTORY_SEPARATOR, $path);
+        $path = \rtrim($path, DIRECTORY_SEPARATOR);
         $arrayPath = \explode(DIRECTORY_SEPARATOR, $path);
         $tmpPath = "";
 

--- a/src/Driver/UvDriver.php
+++ b/src/Driver/UvDriver.php
@@ -205,6 +205,7 @@ final class UvDriver implements Driver
         $this->poll->listen($deferred->promise());
 
         $path = \str_replace("/", DIRECTORY_SEPARATOR, $path);
+        $path = \rtrim($path, DIRECTORY_SEPARATOR);
         $arrayPath = \explode(DIRECTORY_SEPARATOR, $path);
         $tmpPath = "";
 

--- a/test/DriverTest.php
+++ b/test/DriverTest.php
@@ -344,6 +344,16 @@ abstract class DriverTest extends FilesystemTest
         $this->assertSame('0744', $this->getPermissionsFromStatus($stat));
     }
 
+    public function testCreateDirectoryRecursivelySlashEnd(): \Generator
+    {
+        $fixtureDir = Fixture::path();
+
+        $dir = "{$fixtureDir}/newdir/with/recursive/creation/321/";
+
+        $this->assertNull(yield $this->driver->createDirectoryRecursively($dir, 0764));
+        $this->assertTrue(yield $this->driver->exists($dir));
+    }
+
     public function testCreateDirectoryFailsOnNonexistentPath(): \Generator
     {
         $fixtureDir = Fixture::path();


### PR DESCRIPTION
`rtrim()` for path in `createDirectoryRecursively()`